### PR TITLE
feature - get real FileSystem instance

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -127,4 +127,13 @@ abstract class Filesystem extends Component
     {
         return call_user_func_array([$this->filesystem, $method], $parameters);
     }
+
+    /**
+     * @return \League\Flysystem\FilesystemInterface
+     */
+    public function getFileSystem()
+    {
+        return $this->filesystem;
+    }
+    
 }


### PR DESCRIPTION
I think that it is better to depend upon originally file system interface instead of component `creocoder\flysystem\Filesystem`. Because this class is Yii2 specific component.
