### PR TITLE
Feature/allow minio access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- AWS S3: added `pathStyleEndpoint` to allow the use of https://www.minio.io/ as storage service
+
 ## 0.9.1
 
 - all adapters: added getter for native filesystem `getFilesystem()`

--- a/src/AwsS3Filesystem.php
+++ b/src/AwsS3Filesystem.php
@@ -47,6 +47,10 @@ class AwsS3Filesystem extends Filesystem
      */
     public $prefix;
     /**
+     * @var bool
+     */
+    public $pathStyleEndpoint = false;
+    /**
      * @var array
      */
     public $options = [];
@@ -86,6 +90,10 @@ class AwsS3Filesystem extends Filesystem
                 'secret' => $this->secret
             ]
         ];
+
+        if ($this->pathStyleEndpoint === true) {
+            $config['use_path_style_endpoint'] = true;
+        }
 
         if ($this->region !== null) {
             $config['region'] = $this->region;


### PR DESCRIPTION
Hi,

when using minio, the aws adapter need another configuration parameter. I added this parameter and it works like a charm