### PR TITLE
Add support for custom credentials provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.9.3
+
+- AWS S3: added `credentials` for custom credential provider
+
 ## 0.9.2
 
 - AWS S3: added `pathStyleEndpoint` to allow the use of https://www.minio.io/ as storage service

--- a/src/AwsS3Filesystem.php
+++ b/src/AwsS3Filesystem.php
@@ -58,18 +58,24 @@ class AwsS3Filesystem extends Filesystem
      * @var string
      */
     public $endpoint;
+    /**
+     * @var array|\Aws\CacheInterface|\Aws\Credentials\CredentialsInterface|bool|callable
+     */
+    public $credentials;
 
     /**
      * @inheritdoc
      */
     public function init()
     {
-        if ($this->key === null) {
-            throw new InvalidConfigException('The "key" property must be set.');
-        }
+        if ($this->credentials === null) {
+            if ($this->key === null) {
+                throw new InvalidConfigException('The "key" property must be set.');
+            }
 
-        if ($this->secret === null) {
-            throw new InvalidConfigException('The "secret" property must be set.');
+            if ($this->secret === null) {
+                throw new InvalidConfigException('The "secret" property must be set.');
+            }
         }
 
         if ($this->bucket === null) {
@@ -84,12 +90,14 @@ class AwsS3Filesystem extends Filesystem
      */
     protected function prepareAdapter()
     {
-        $config = [
-            'credentials' => [
-                'key' => $this->key,
-                'secret' => $this->secret
-            ]
-        ];
+        $config = [];
+
+        if ($this->credentials === null) {
+            $config['credentials'] = ['key' => $this->key, 'secret' => $this->secret];
+        } else {
+            $config['credentials'] = $this->credentials;
+        }
+
 
         if ($this->pathStyleEndpoint === true) {
             $config['use_path_style_endpoint'] = true;


### PR DESCRIPTION
Close #35 

Credentials for s3 are provided by ec2 instance (https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#credentials).

With this pr its possible to pass $credentials and skip `key` and `secret` validation. To use the default s3 behaviour you could use something like this

```
use Aws\Credentials\CredentialProvider;

return [
    'class' => 'creocoder\flysystem\AwsS3Filesystem',
    'credentials' => CredentialProvider::defaultProvider(),
];
```

Wrap `defaultProvider` in `memoize` for best performance

```
use Aws\Credentials\CredentialProvider;

return [
    'class' => 'creocoder\flysystem\AwsS3Filesystem',
    'credentials' => CredentialProvider::memoize(
        CredentialProvider::defaultProvider()
    ),
];
```

@petrabarus @and186