### PR TITLE
add enableTimestampsOnUnixListings option to FtpFilesystem

### DIFF
--- a/src/FtpFilesystem.php
+++ b/src/FtpFilesystem.php
@@ -62,6 +62,10 @@ class FtpFilesystem extends Filesystem
      * @var integer
      */
     public $transferMode;
+    /**
+     * @var bool
+     */
+    public $enableTimestampsOnUnixListings = false;
 
     /**
      * @inheritdoc
@@ -98,6 +102,7 @@ class FtpFilesystem extends Filesystem
             'permPublic',
             'passive',
             'transferMode',
+            'enableTimestampsOnUnixListings',
         ] as $name) {
             if ($this->$name !== null) {
                 $config[$name] = $this->$name;


### PR DESCRIPTION
This PR adds the option `enableTimestampsOnUnixListings` from the class \League\Flysystem\Adapter\Ftp to the FtpFilesystem, which enables getting file timestamps directly from the ftp list cmd without having to call getTimestamp() for each file separately.

see: https://github.com/thephpleague/flysystem/blob/v1.0/src/Adapter/AbstractFtpAdapter.php#L451