### PR TITLE
Updated dropbox adapter library to use dropbox v2 api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "league/flysystem-azure": "~1.0",
         "league/flysystem-cached-adapter": "~1.0",
         "league/flysystem-copy": "~1.0",
-        "league/flysystem-dropbox": "~1.0",
+        "spatie/flysystem-dropbox": "~1.0",
         "league/flysystem-gridfs": "~1.0",
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-replicate-adapter": "~1.0",

--- a/src/DropboxFilesystem.php
+++ b/src/DropboxFilesystem.php
@@ -7,8 +7,8 @@
 
 namespace creocoder\flysystem;
 
-use Dropbox\Client;
-use League\Flysystem\Dropbox\DropboxAdapter;
+use Spatie\Dropbox\Client;
+use Spatie\FlysystemDropbox\DropboxAdapter;
 use yii\base\InvalidConfigException;
 
 /**
@@ -53,8 +53,7 @@ class DropboxFilesystem extends Filesystem
     protected function prepareAdapter()
     {
         return new DropboxAdapter(
-            new Client($this->token, $this->app),
-            $this->prefix
+            new Client($this->token, $this->prefix),
         );
     }
 }


### PR DESCRIPTION
Updated dropbox adapter library to use dropbox v2 api, since the league/flysystem-dropbox library is still using dropbox api v1 and it is also abondoned, I replaced it with spatie/flysystem-dropbox.